### PR TITLE
Support hadoop 2.7 3.2 azure blob

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## kolo-objectstore-dep
+## byzer-objectstore-dep
 
 ### build shade jar
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 ### build shade jar
 
-```
- mvn package -pl azure-blob -Pshade
+```shell
+# hadoop-2.7 compatible
+mvn package -pl azure-blob -Pshade -Phadoop-2.7
+# hadoop-3.2 compatible
+mvn package -pl azure-blob -Pshade -Phadoop-3.2 
 ```

--- a/azure-blob/pom.xml
+++ b/azure-blob/pom.xml
@@ -9,28 +9,61 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>azure-blob</artifactId>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-azure</artifactId>
-            <version>3.2.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.9.5</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.9.5</version>
-        </dependency>
-    </dependencies>
-
+    <artifactId>azure-blob_${hadoop.version}</artifactId>
     <profiles>
+        <profile>
+            <id>hadoop-2.7</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <hadoop.version>2.7</hadoop.version>
+            </properties>
+
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-azure</artifactId>
+                    <version>2.7.0</version>
+                </dependency>
+
+                <dependency>
+                    <groupId>com.microsoft.azure</groupId>
+                    <artifactId>azure-storage</artifactId>
+                    <version>2.0.0</version>
+                </dependency>
+
+            </dependencies>
+        </profile>
+        <profile>
+            <id>hadoop-3.2</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <hadoop.version>3.2</hadoop.version>
+            </properties>
+
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-azure</artifactId>
+                    <version>3.2.0</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                    <version>2.9.5</version>
+                </dependency>
+
+                <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                    <version>2.9.5</version>
+                </dependency>
+            </dependencies>
+        </profile>
+
         <profile>
             <id>shade</id>
             <build>

--- a/azure-blob/pom.xml
+++ b/azure-blob/pom.xml
@@ -9,17 +9,61 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>azure-blob</artifactId>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-azure</artifactId>
-            <version>3.3.1</version>
-        </dependency>
-    </dependencies>
-
+    <artifactId>azure-blob_${hadoop.version}</artifactId>
     <profiles>
+        <profile>
+            <id>hadoop-2.7</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <hadoop.version>2.7</hadoop.version>
+            </properties>
+
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-azure</artifactId>
+                    <version>2.7.0</version>
+                </dependency>
+
+                <dependency>
+                    <groupId>com.microsoft.azure</groupId>
+                    <artifactId>azure-storage</artifactId>
+                    <version>2.0.0</version>
+                </dependency>
+
+            </dependencies>
+        </profile>
+        <profile>
+            <id>hadoop-3.2</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <hadoop.version>3.2</hadoop.version>
+            </properties>
+
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-azure</artifactId>
+                    <version>3.2.0</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                    <version>2.9.5</version>
+                </dependency>
+
+                <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                    <version>2.9.5</version>
+                </dependency>
+            </dependencies>
+        </profile>
+
         <profile>
             <id>shade</id>
             <build>
@@ -44,6 +88,14 @@
                                 <relocation>
                                     <pattern>org.eclipse.jetty</pattern>
                                     <shadedPattern>shadeio.jetty</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson.core</pattern>
+                                    <shadedPattern>shadeio.com.fasterxml.jackson.core</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson.databind</pattern>
+                                    <shadedPattern>shadeio.com.fasterxml.jackson.databind</shadedPattern>
                                 </relocation>
                                 <!--                                <relocation>-->
                                 <!--                                    <pattern>org.apache.httpcomponents</pattern>-->

--- a/azure-blob/pom.xml
+++ b/azure-blob/pom.xml
@@ -15,7 +15,18 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-azure</artifactId>
-            <version>3.3.1</version>
+            <version>3.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.9.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.5</version>
         </dependency>
     </dependencies>
 
@@ -44,6 +55,14 @@
                                 <relocation>
                                     <pattern>org.eclipse.jetty</pattern>
                                     <shadedPattern>shadeio.jetty</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson.core</pattern>
+                                    <shadedPattern>shadeio.com.fasterxml.jackson.core</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson.databind</pattern>
+                                    <shadedPattern>shadeio.com.fasterxml.jackson.databind</shadedPattern>
                                 </relocation>
                                 <!--                                <relocation>-->
                                 <!--                                    <pattern>org.apache.httpcomponents</pattern>-->


### PR DESCRIPTION
## Changes in PR
To enable different versions of spark based application access azure blob, this pr introduces different profiles respectively.
For spark-2.4.3-bin-hadoop2.7 , please enable profile hadoop-2.7, spark-3.1.1-bin-hadoop3.2, please enable hadoop-3.2.
The build command is in the README.md